### PR TITLE
fix: resolve CI check failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ["stable", "beta", "nightly", "1.65"] # MSRV
+        rust: ["stable", "beta", "nightly", "1.85"] # MSRV
         flags: ["--no-default-features", "", "--all-features"]
         exclude:
           # Skip because some features have higher MSRV.
-          - rust: "1.65" # MSRV
+          - rust: "1.85" # MSRV
             flags: "--all-features"
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
           cache-on-failure: true
       # Only run tests on latest stable and above
       - name: Check
-        if: ${{ matrix.rust == '1.65' }} # MSRV
+        if: ${{ matrix.rust == '1.85' }} # MSRV
         run: cargo check ${{ matrix.flags }}
 
       # Cargo doc test is not included in `--all-targets` so we call it separately.
@@ -52,12 +52,12 @@ jobs:
       # Cargo doc test also doesn't support `--no-run`, so we run it but
       # have it just print `--help`.
       - name: Build tests
-        if: ${{ matrix.rust != '1.65' }} # MSRV
+        if: ${{ matrix.rust != '1.85' }} # MSRV
         run: |
           cargo test --workspace ${{ matrix.flags }} --all-targets --no-run
           cargo test --workspace ${{ matrix.flags }} --doc -- --help
       - name: Run tests
-        if: ${{ matrix.rust != '1.65' }} # MSRV
+        if: ${{ matrix.rust != '1.85' }} # MSRV
         run: |
           cargo test --workspace ${{ matrix.flags }} --all-targets -- --nocapture
           cargo test --workspace ${{ matrix.flags }} --doc -- --nocapture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.85"
 authors = ["Remco Bloemen <remco@wicked.ventures>"]
 license = "MIT"
 homepage = "https://github.com/recmo/uint"

--- a/deny.toml
+++ b/deny.toml
@@ -3,6 +3,9 @@ version = 2
 ignore = [
     { id = "RUSTSEC-2024-0388", reason = "this is an unmaintained transitive subdep of a dev dep" },
     { id = "RUSTSEC-2024-0436", reason = "this is an unmaintained transitive subdep of a dep" },
+    { id = "RUSTSEC-2025-0141", reason = "this is an unmaintained dep, but we support it as a feature" },
+    { id = "RUSTSEC-2025-0020", reason = "pyo3 support does not call PyString::from_object" },
+    { id = "RUSTSEC-2026-0177", reason = "pyo3 support does not use the affected closure API" },
 ]
 
 [bans]


### PR DESCRIPTION
Bumps the MSRV to 1.85 and fixes the `cargo deny` failures by ignoring them in deny.toml

closes INT-8225